### PR TITLE
fix: Updating phat hello world contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,22 +5,18 @@ authors = ["Shelven Zhou <shelvenzhou@phala.network>"]
 edition = "2021"
 
 [dependencies]
-ink_prelude = { version = "3.3", default-features = false }
-ink_primitives = { version = "3.3", default-features = false }
-ink_metadata = { version = "3.3", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.3", default-features = false }
-ink_storage = { version = "3.3", default-features = false }
-ink_lang = { version = "3.3", default-features = false }
+ink = { version = "4", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale = { package = "parity-scale-codec", version = "3.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.1", default-features = false, features = ["derive"], optional = true }
 
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-json-core = { version = "0.4.0" }
-pink-extension = { version = "0.1", default-features = false }
+
+pink-extension = { version = "0.4", default-features = false }
 
 [dev-dependencies]
-pink-extension-runtime = "0.1"
+pink-extension-runtime = { version = "0.4", default-features = false }
 
 [lib]
 name = "phat_hello"
@@ -33,10 +29,7 @@ crate-type = [
 [features]
 default = ["std"]
 std = [
-    "ink_metadata/std",
-    "ink_env/std",
-    "ink_storage/std",
-    "ink_primitives/std",
+    "ink/std",
     "scale/std",
     "scale-info/std",
     "pink-extension/std",

--- a/lib.rs
+++ b/lib.rs
@@ -7,10 +7,12 @@ use pink_extension as pink;
 #[pink::contract(env=PinkEnvironment)]
 mod phat_hello {
     use super::pink;
-    use ink_prelude::{format, string::String};
     use pink::{http_get, PinkEnvironment};
     use scale::{Decode, Encode};
     use serde::Deserialize;
+    use alloc::string::String;
+    use alloc::format;
+
     // you have to use crates with `no_std` support in contract.
     use serde_json_core;
 
@@ -80,8 +82,6 @@ mod phat_hello {
     mod tests {
         /// Imports all the definitions from the outer scope so we can use them here.
         use super::*;
-        /// Imports `ink_lang` so we can use `#[ink::test]`.
-        use ink_lang as ink;
 
         /// We test a simple use case of our contract.
         #[ink::test]


### PR DESCRIPTION
Upgrading to the latest version of ink and removal of old dependencies.
Added `pink-extension-runtime` as a dev dependency. 

Including `format` and `String`.